### PR TITLE
Add skeleton BrandToneCraft app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BrandToneCraft</title>
+  <script type="module" src="/src/pages/index.tsx"></script>
+</head>
+<body class="min-h-screen bg-gray-50">
+  <div id="root"></div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ctbl-prototype",
+  "version": "1.0.0",
+  "description": "BrandToneCraft prototype",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/BrandUploader.tsx
+++ b/src/components/BrandUploader.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+interface Props {
+  onUpload: (text: string) => void
+}
+
+export const BrandUploader: React.FC<Props> = ({ onUpload }) => {
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => onUpload(String(reader.result))
+    reader.readAsText(file)
+  }
+
+  return (
+    <div className="p-4 border rounded">
+      <input type="file" accept=".txt" onChange={handleFile} />
+    </div>
+  )
+}

--- a/src/components/CopyOutput.tsx
+++ b/src/components/CopyOutput.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useStore } from '../store'
+import { openaiCompletion } from '../lib/llmAdapters/openai'
+
+export const CopyOutput: React.FC = () => {
+  const prompt = useStore(s => s.prompt)
+  const [output, setOutput] = React.useState('')
+
+  const handleRun = async () => {
+    const res = await openaiCompletion(prompt)
+    setOutput(res)
+  }
+
+  return (
+    <div className="space-y-2">
+      <button className="px-4 py-2 bg-green-600 text-white" onClick={handleRun}>
+        Run Prompt
+      </button>
+      <pre className="p-2 border bg-white whitespace-pre-wrap">{output}</pre>
+    </div>
+  )
+}

--- a/src/components/LLMSelector.tsx
+++ b/src/components/LLMSelector.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useStore } from '../store'
+
+const providers = ['openai', 'anthropic', 'mistral'] as const
+
+export const LLMSelector: React.FC = () => {
+  const provider = useStore(s => s.provider)
+  const setProvider = useStore(s => s.setProvider)
+
+  return (
+    <select value={provider} onChange={e => setProvider(e.target.value as any)}>
+      {providers.map(p => (
+        <option key={p} value={p}>{p}</option>
+      ))}
+    </select>
+  )
+}

--- a/src/components/PromptBuilder.tsx
+++ b/src/components/PromptBuilder.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useStore } from '../store'
+
+export const PromptBuilder: React.FC = () => {
+  const tone = useStore(s => s.tone)
+  const prompt = `Write marketing copy in the following tone: ${tone}`
+  const setPrompt = useStore(s => s.setPrompt)
+
+  React.useEffect(() => {
+    setPrompt(prompt)
+  }, [tone])
+
+  return (
+    <textarea
+      className="w-full p-2 border"
+      rows={4}
+      value={prompt}
+      readOnly
+    />
+  )
+}

--- a/src/components/ToneGenerator.tsx
+++ b/src/components/ToneGenerator.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { useStore } from '../store'
+import { generateTone } from '../lib/promptTemplates'
+
+export const ToneGenerator: React.FC = () => {
+  const brandText = useStore(s => s.brandText)
+  const setTone = useStore(s => s.setTone)
+
+  const handleGenerate = () => {
+    if (!brandText) return
+    setTone(generateTone(brandText))
+  }
+
+  return (
+    <button className="px-4 py-2 bg-blue-600 text-white" onClick={handleGenerate}>
+      Generate Tone
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/lib/llmAdapters/anthropic.ts
+++ b/src/lib/llmAdapters/anthropic.ts
@@ -1,0 +1,4 @@
+export async function anthropicCompletion(prompt: string): Promise<string> {
+  console.log('Sending to Anthropic:', prompt)
+  return Promise.resolve('Anthropic response for: ' + prompt)
+}

--- a/src/lib/llmAdapters/mistral.ts
+++ b/src/lib/llmAdapters/mistral.ts
@@ -1,0 +1,4 @@
+export async function mistralCompletion(prompt: string): Promise<string> {
+  console.log('Sending to Mistral:', prompt)
+  return Promise.resolve('Mistral response for: ' + prompt)
+}

--- a/src/lib/llmAdapters/openai.ts
+++ b/src/lib/llmAdapters/openai.ts
@@ -1,0 +1,5 @@
+export async function openaiCompletion(prompt: string): Promise<string> {
+  // Placeholder fetch - replace with real API call
+  console.log('Sending to OpenAI:', prompt)
+  return Promise.resolve('OpenAI response for: ' + prompt)
+}

--- a/src/lib/promptTemplates.ts
+++ b/src/lib/promptTemplates.ts
@@ -1,0 +1,3 @@
+export function generateTone(text: string): string {
+  return `Tone extracted from: ${text.substring(0, 50)}...`
+}

--- a/src/pages/compare.tsx
+++ b/src/pages/compare.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { useStore } from '../store'
+import { openaiCompletion } from '../lib/llmAdapters/openai'
+import { anthropicCompletion } from '../lib/llmAdapters/anthropic'
+import { mistralCompletion } from '../lib/llmAdapters/mistral'
+import '../index.css'
+
+const App: React.FC = () => {
+  const prompt = useStore(s => s.prompt)
+  const [results, setResults] = React.useState<Record<string, string>>({})
+
+  const handleRun = async () => {
+    setResults({
+      openai: await openaiCompletion(prompt),
+      anthropic: await anthropicCompletion(prompt),
+      mistral: await mistralCompletion(prompt),
+    })
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <button className="px-4 py-2 bg-blue-600 text-white" onClick={handleRun}>
+        Compare Models
+      </button>
+      {Object.entries(results).map(([key, val]) => (
+        <div key={key} className="border p-2">
+          <strong>{key}</strong>
+          <pre>{val}</pre>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrandUploader } from '../components/BrandUploader'
+import { ToneGenerator } from '../components/ToneGenerator'
+import { PromptBuilder } from '../components/PromptBuilder'
+import { CopyOutput } from '../components/CopyOutput'
+import { LLMSelector } from '../components/LLMSelector'
+import { useStore } from '../store'
+import '../index.css'
+
+const App: React.FC = () => {
+  const setBrandText = useStore(s => s.setBrandText)
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">BrandToneCraft</h1>
+      <BrandUploader onUpload={setBrandText} />
+      <ToneGenerator />
+      <PromptBuilder />
+      <LLMSelector />
+      <CopyOutput />
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />)

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,24 @@
+import create from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface State {
+  brandText: string
+  tone: string
+  prompt: string
+  provider: 'openai' | 'anthropic' | 'mistral'
+  setBrandText: (t: string) => void
+  setTone: (t: string) => void
+  setPrompt: (p: string) => void
+  setProvider: (p: 'openai' | 'anthropic' | 'mistral') => void
+}
+
+export const useStore = create<State>(persist((set) => ({
+  brandText: '',
+  tone: '',
+  prompt: '',
+  provider: 'openai',
+  setBrandText: (brandText) => set({ brandText }),
+  setTone: (tone) => set({ tone }),
+  setPrompt: (prompt) => set({ prompt }),
+  setProvider: (provider) => set({ provider }),
+}), { name: 'btc-store' }))

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,7 @@
+export function saveKey(provider: string, key: string) {
+  localStorage.setItem(`btc-key-${provider}`, key)
+}
+
+export function loadKey(provider: string): string {
+  return localStorage.getItem(`btc-key-${provider}`) || ''
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 3000 },
+})


### PR DESCRIPTION
## Summary
- set up Vite + React + TypeScript scaffold
- add core components (BrandUploader, ToneGenerator, PromptBuilder, CopyOutput, LLMSelector)
- implement simple Zustand store and adapter placeholders
- supply pages for index and comparison view
- add Tailwind setup and configs

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test`