### PR TITLE
Add API key manager and real LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ src/
 
 ## 🔑 API Keys
 
-* You will be prompted in-app to provide API keys for each LLM provider.
-* These are stored **locally** in your browser for the current session only.
-* Ensure you have access to the APIs for OpenAI, Claude (Anthropic), or others.
+* Use the **API Key Manager** section in the app to enter your keys for OpenAI,
+  Anthropic, or Mistral.
+* Keys are stored **locally** in your browser for the current session only.
+* Ensure you have access to the respective provider APIs.
 
 ## 🧪 Testing
 

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { saveKey, loadKey } from '../utils/storage'
+
+interface Props {
+  provider: 'openai' | 'anthropic' | 'mistral'
+}
+
+export const ApiKeyInput: React.FC<Props> = ({ provider }) => {
+  const [key, setKey] = React.useState('')
+
+  React.useEffect(() => {
+    setKey(loadKey(provider))
+  }, [provider])
+
+  const handleSave = () => {
+    saveKey(provider, key)
+    alert('Key saved')
+  }
+
+  return (
+    <div className="flex space-x-2 items-center">
+      <input
+        type="password"
+        className="flex-1 p-2 border rounded"
+        placeholder={`${provider} API key`}
+        value={key}
+        onChange={e => setKey(e.target.value)}
+      />
+      <button className="px-3 py-1 bg-blue-600 text-white" onClick={handleSave}>
+        Save
+      </button>
+    </div>
+  )
+}

--- a/src/components/ApiKeyManager.tsx
+++ b/src/components/ApiKeyManager.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { ApiKeyInput } from './ApiKeyInput'
+
+const providers = ['openai', 'anthropic', 'mistral'] as const
+
+type Provider = typeof providers[number]
+
+export const ApiKeyManager: React.FC = () => {
+  return (
+    <div className="space-y-2">
+      {providers.map(p => (
+        <ApiKeyInput key={p} provider={p as Provider} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/CopyOutput.tsx
+++ b/src/components/CopyOutput.tsx
@@ -1,13 +1,23 @@
 import React from 'react'
 import { useStore } from '../store'
 import { openaiCompletion } from '../lib/llmAdapters/openai'
+import { anthropicCompletion } from '../lib/llmAdapters/anthropic'
+import { mistralCompletion } from '../lib/llmAdapters/mistral'
 
 export const CopyOutput: React.FC = () => {
   const prompt = useStore(s => s.prompt)
+  const provider = useStore(s => s.provider)
   const [output, setOutput] = React.useState('')
 
   const handleRun = async () => {
-    const res = await openaiCompletion(prompt)
+    let res = ''
+    if (provider === 'openai') {
+      res = await openaiCompletion(prompt)
+    } else if (provider === 'anthropic') {
+      res = await anthropicCompletion(prompt)
+    } else {
+      res = await mistralCompletion(prompt)
+    }
     setOutput(res)
   }
 

--- a/src/lib/llmAdapters/anthropic.ts
+++ b/src/lib/llmAdapters/anthropic.ts
@@ -1,4 +1,20 @@
+import { loadKey } from '../../utils/storage'
+
 export async function anthropicCompletion(prompt: string): Promise<string> {
-  console.log('Sending to Anthropic:', prompt)
-  return Promise.resolve('Anthropic response for: ' + prompt)
+  const key = loadKey('anthropic')
+  const res = await fetch('https://api.anthropic.com/v1/complete', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-instant-1',
+      prompt,
+      max_tokens_to_sample: 200,
+    }),
+  })
+  const data = await res.json()
+  return data.completion?.trim() || ''
 }

--- a/src/lib/llmAdapters/mistral.ts
+++ b/src/lib/llmAdapters/mistral.ts
@@ -1,4 +1,19 @@
+import { loadKey } from '../../utils/storage'
+
 export async function mistralCompletion(prompt: string): Promise<string> {
-  console.log('Sending to Mistral:', prompt)
-  return Promise.resolve('Mistral response for: ' + prompt)
+  const key = loadKey('mistral')
+  const res = await fetch('https://api.mistral.ai/v1/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: 'mistral-tiny',
+      prompt,
+      max_tokens: 200,
+    }),
+  })
+  const data = await res.json()
+  return data.choices?.[0]?.text?.trim() || ''
 }

--- a/src/lib/llmAdapters/openai.ts
+++ b/src/lib/llmAdapters/openai.ts
@@ -1,5 +1,19 @@
+import { loadKey } from '../../utils/storage'
+
 export async function openaiCompletion(prompt: string): Promise<string> {
-  // Placeholder fetch - replace with real API call
-  console.log('Sending to OpenAI:', prompt)
-  return Promise.resolve('OpenAI response for: ' + prompt)
+  const key = loadKey('openai')
+  const res = await fetch('https://api.openai.com/v1/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: 'text-davinci-003',
+      prompt,
+      max_tokens: 200,
+    }),
+  })
+  const data = await res.json()
+  return data.choices?.[0]?.text?.trim() || ''
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { ToneGenerator } from '../components/ToneGenerator'
 import { PromptBuilder } from '../components/PromptBuilder'
 import { CopyOutput } from '../components/CopyOutput'
 import { LLMSelector } from '../components/LLMSelector'
+import { ApiKeyManager } from '../components/ApiKeyManager'
 import { useStore } from '../store'
 import '../index.css'
 
@@ -17,6 +18,7 @@ const App: React.FC = () => {
       <ToneGenerator />
       <PromptBuilder />
       <LLMSelector />
+      <ApiKeyManager />
       <CopyOutput />
     </div>
   )


### PR DESCRIPTION
## Summary
- add APIKeyInput and APIKeyManager components for storing API keys locally
- call selected LLM provider when running prompt
- implement actual fetch logic for OpenAI, Anthropic and Mistral adapters
- display API key manager in main page
- update README about API key manager

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test`