### PR TITLE
Add script for uploading Vite dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ src/
    ```bash
    npm run build
    ```
+5. **Package and upload dependencies** (optional):
+   Set `REMOTE_HOST` and `REMOTE_PATH` then run:
+   ```bash
+   REMOTE_HOST=user@server REMOTE_PATH=/path/to/dir ./scripts/upload-vite-deps.sh
+   ```
 
 ## 🔑 API Keys
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "echo 'no tests'"
+    "test": "echo 'no tests'",
+    "upload-deps": "bash ./scripts/upload-vite-deps.sh"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/upload-vite-deps.sh
+++ b/scripts/upload-vite-deps.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script builds the Vite project, packages the resulting assets and Node
+# dependencies, and uploads them to a remote server. Set the environment
+# variables REMOTE_HOST and REMOTE_PATH to specify the upload destination.
+
+set -euo pipefail
+
+if [ ! -f package.json ]; then
+  echo "Error: run this script from the project root" >&2
+  exit 1
+fi
+
+# Install dependencies if node_modules doesn't exist
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Build the project for production
+echo "Building project..."
+npm run build
+
+# Package node_modules and the build output
+ARCHIVE_NAME="vite-deps.tar.gz"
+
+# Include the dist directory if it exists
+if [ -d dist ]; then
+  tar -czf "$ARCHIVE_NAME" node_modules dist
+else
+  tar -czf "$ARCHIVE_NAME" node_modules
+fi
+
+echo "Created archive $ARCHIVE_NAME"
+
+if [ -z "${REMOTE_HOST:-}" ] || [ -z "${REMOTE_PATH:-}" ]; then
+  echo "REMOTE_HOST and REMOTE_PATH environment variables not set. Skipping upload."
+  exit 0
+fi
+
+# Upload the archive using scp
+scp "$ARCHIVE_NAME" "$REMOTE_HOST":"$REMOTE_PATH"
+
+echo "Uploaded $ARCHIVE_NAME to $REMOTE_HOST:$REMOTE_PATH"


### PR DESCRIPTION
## Summary
- add `upload-vite-deps.sh` to package node_modules and build artifacts and upload them
- expose new script via `npm run upload-deps`
- document optional upload step in README

## Testing
- `npm run test`